### PR TITLE
New dismantle ammo option

### DIFF
--- a/gamedata/configs/text/eng/ui_mcm_auto_looter.xml
+++ b/gamedata/configs/text/eng/ui_mcm_auto_looter.xml
@@ -152,6 +152,9 @@
 	<string id="ui_mcm_lst_auto_looter_non_favourite_label">
 		<text>Non-favourite only</text>
 	</string>
+	<string id="ui_mcm_lst_auto_looter_junk_itms_label">
+		<text>Items Marked as Junk only</text>
+	</string>
 	<string id="ui_mcm_lst_auto_looter_with_usable_parts_label">
 		<text>With usable parts</text>
 	</string>

--- a/gamedata/scripts/auto_looter_mcm.script
+++ b/gamedata/scripts/auto_looter_mcm.script
@@ -1,6 +1,7 @@
 disassemble_ammo_options = {
 	all = "all",
 	non_favourite = "non_favourite",
+	junk_itms = "junk_itms",
 	none = "none"
 }
 
@@ -149,6 +150,7 @@ op = {
         {id = "disassemble_ammo", type="list", val=0, def=config.disassemble_ammo, content={
 			{disassemble_ammo_options.all, "auto_looter_all_label"},
 			{disassemble_ammo_options.non_favourite, "auto_looter_non_favourite_label"},
+			{disassemble_ammo_options.junk_itms, "auto_looter_junk_itms_label"},
 			{disassemble_ammo_options.none, "auto_looter_none_label"},
 		  }
 		},

--- a/gamedata/scripts/z_auto_looter.script
+++ b/gamedata/scripts/z_auto_looter.script
@@ -56,6 +56,7 @@ local ammo_parts_sections = {
 }
 
 local favorite_itms = {}
+local junk_itms = {}
 local actors_being_processed = {}
 
 function is_right_key(key)
@@ -222,11 +223,6 @@ function cond_ammo_disassemble(obj)
 	if config.disassemble_ammo == disassemble_ammo_options.non_favourite then
 		if not favorite_itms[obj:section()] then
 			return true
-		end
-	end
-	if config.disassemble_ammo == disassemble_ammo_options.junk_itms then
-		if not junk_itms[obj:section()] then
-			return false
 		end
 	end
 	if config.disassemble_ammo == disassemble_ammo_options.junk_itms then

--- a/gamedata/scripts/z_auto_looter.script
+++ b/gamedata/scripts/z_auto_looter.script
@@ -224,6 +224,16 @@ function cond_ammo_disassemble(obj)
 			return true
 		end
 	end
+	if config.disassemble_ammo == disassemble_ammo_options.junk_itms then
+		if not junk_itms[obj:section()] then
+			return false
+		end
+	end
+	if config.disassemble_ammo == disassemble_ammo_options.junk_itms then
+		if junk_itms[obj:section()] then
+			return true
+		end
+	end
 	return false
 end
 
@@ -435,6 +445,7 @@ end
 
 local function load_state(mdata)
     favorite_itms = mdata.rax_favorite_itms or favorite_itms
+	junk_itms = mdata.rax_junk_itms or junk_itms
 end
 
 function is_misc_item_defined_in_disassemble_config(obj)


### PR DESCRIPTION
Adds the ability in MCM to dismantle ammo which the player has marked as junk and (shouldnt) affect anything else.

Have downloaded this as a .zip and tested in game with a stack of ammo marked as fave/norm/junk and only the junk ammo was dismantled when auto looted.